### PR TITLE
action_items: add reactions

### DIFF
--- a/src/extensions/action_items.py
+++ b/src/extensions/action_items.py
@@ -161,7 +161,9 @@ async def action_item_reaction(event: hikari.GuildReactionAddEvent) -> None:
     has_mentioned_role = any(role_id in mentioned_ids for role_id in member.role_ids)
 
     # cross out the action item, if it was not crossed out already
-    if (is_mentioned_user or has_mentioned_role) and not message.content.startswith("- ✅ ~~"):
+    if (is_mentioned_user or has_mentioned_role) and not message.content.startswith(
+        "- ✅ ~~"
+    ):
         # add strikethrough and checkmark
         updated_content = f"- ✅ ~~{message.content[2:]}~~"
         await action_items.client.rest.edit_message(

--- a/src/extensions/action_items.py
+++ b/src/extensions/action_items.py
@@ -160,9 +160,10 @@ async def action_item_reaction(event: hikari.GuildReactionAddEvent) -> None:
     is_mentioned_user = event.user_id in mentioned_ids
     has_mentioned_role = any(role_id in mentioned_ids for role_id in member.role_ids)
 
-    if is_mentioned_user or has_mentioned_role:
+    # cross out the action item, if it was not crossed out already
+    if (is_mentioned_user or has_mentioned_role) and not message.content.startswith("- ✅ ~~"):
         # add strikethrough and checkmark
-        updated_content = f"- ✅ ~~{message.content[1:]}~~"
+        updated_content = f"- ✅ ~~{message.content[2:]}~~"
         await action_items.client.rest.edit_message(
             event.channel_id, event.message_id, content=updated_content
         )


### PR DESCRIPTION
Closes https://github.com/redbrick/blockbot/issues/57

- Adds ✅ reaction to each action item message
- Once one of the users mentioned in the action item message reacts the message is edited, crossing it out and adding a checkmark

**NOTE**: I have no idea what I'm doing, there is definitely a better way of doing this, This was put together from [`boosts.py`](https://github.com/redbrick/blockbot/blob/main/src/extensions/boosts.py) and stumbling through the hikari docs.
Some sort of hooks here might work, along with a better way of verifying the user and bot ids.
**I have not tested role ids and its probably half broken :heart:**