### PR TITLE
Add bot "feature" modes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 TOKEN=
-DEBUG=false  # or 'true', default 'false'
+DEBUG=  # 'true' or 'false', default 'false'
 
 DISCORD_UID_MAP="user1=1234,user2=4567,user3=7890"
 
@@ -14,7 +14,7 @@ DB_USER=blockbot
 DB_PASSWORD=
 
 # all of these can be set to 'false' and default to 'true'
-DB_ENABLED=true
-RCON_ENABLED=true
-LDAP_ENABLED=true
-PERMS_ENABLED=true
+DB_ENABLED=
+RCON_ENABLED=
+LDAP_ENABLED=
+PERMS_ENABLED=

--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,7 @@ LDAP_PASSWORD=
 
 AGENDA_TEMPLATE_URL="https://md.redbrick.dcu.ie/foo"
 
+DB_ENABLED= # false, or anything
 DB_HOST=postgres:5432
 DB_NAME=blockbot
 DB_USER=blockbot

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 TOKEN=
-DEBUG=
+DEBUG=false  # or 'true', default 'false'
 
 DISCORD_UID_MAP="user1=1234,user2=4567,user3=7890"
 
@@ -8,8 +8,13 @@ LDAP_PASSWORD=
 
 AGENDA_TEMPLATE_URL="https://md.redbrick.dcu.ie/foo"
 
-DB_ENABLED= # false, or anything
 DB_HOST=postgres:5432
 DB_NAME=blockbot
 DB_USER=blockbot
 DB_PASSWORD=
+
+# all of these can be set to 'false' and default to 'true'
+DB_ENABLED=true
+RCON_ENABLED=true
+LDAP_ENABLED=true
+PERMS_ENABLED=true

--- a/.env.sample
+++ b/.env.sample
@@ -15,6 +15,5 @@ DB_PASSWORD=
 
 # all of these can be set to 'false' and default to 'true'
 DB_ENABLED=
-RCON_ENABLED=
 LDAP_ENABLED=
 PERMS_ENABLED=

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,19 +12,19 @@ options.sessions = ["format_fix", "pyright"]
 
 @nox.session()
 def format_fix(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "-q", "--only-dev", "--active")
-    session.run("uv", "run", "--active", "ruff", "format", *SCRIPT_PATHS)
-    session.run("uv", "run", "--active", "ruff", "check", *SCRIPT_PATHS, "--fix")
+    session.run_install("uv", "sync", "--only-dev", "--active")
+    session.run("python", "-m", "ruff", "format", *SCRIPT_PATHS)
+    session.run("python", "-m", "ruff", "check", *SCRIPT_PATHS, "--fix")
 
 
 @nox.session()
 def format_check(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "-q", "--only-dev", "--active")
-    session.run("uv", "run", "--active", "ruff", "format", *SCRIPT_PATHS, "--check")
-    session.run("uv", "run", "--active", "ruff", "check", *SCRIPT_PATHS)
+    session.run_install("uv", "sync", "--only-dev", "--active")
+    session.run("python", "-m", "ruff", "format", *SCRIPT_PATHS, "--check")
+    session.run("python", "-m", "ruff", "check", *SCRIPT_PATHS)
 
 
 @nox.session()
 def pyright(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "-q", "--dev", "--group", "nox", "--active")
-    session.run("uv", "run", "--active", "pyright", *SCRIPT_PATHS)
+    session.run_install("uv", "sync", "--dev", "--group", "nox", "--active")
+    session.run("pyright", *SCRIPT_PATHS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,19 +12,19 @@ options.sessions = ["format_fix", "pyright"]
 
 @nox.session()
 def format_fix(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "--only-dev", "--active")
-    session.run("python", "-m", "ruff", "format", *SCRIPT_PATHS)
-    session.run("python", "-m", "ruff", "check", *SCRIPT_PATHS, "--fix")
+    session.run_install("uv", "sync", "-q", "--only-dev", "--active")
+    session.run("uv", "run", "--active", "ruff", "format", *SCRIPT_PATHS)
+    session.run("uv", "run", "--active", "ruff", "check", *SCRIPT_PATHS, "--fix")
 
 
 @nox.session()
 def format_check(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "--only-dev", "--active")
-    session.run("python", "-m", "ruff", "format", *SCRIPT_PATHS, "--check")
-    session.run("python", "-m", "ruff", "check", *SCRIPT_PATHS)
+    session.run_install("uv", "sync", "-q", "--only-dev", "--active")
+    session.run("uv", "run", "--active", "ruff", "format", *SCRIPT_PATHS, "--check")
+    session.run("uv", "run", "--active", "ruff", "check", *SCRIPT_PATHS)
 
 
 @nox.session()
 def pyright(session: nox.Session) -> None:
-    session.run_install("uv", "sync", "--dev", "--group", "nox", "--active")
-    session.run("pyright", *SCRIPT_PATHS)
+    session.run_install("uv", "sync", "-q", "--dev", "--group", "nox", "--active")
+    session.run("uv", "run", "--active", "pyright", *SCRIPT_PATHS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ nox = [
 ]
 
 [tool.ruff]
-include = [".src/*.py", "noxfile.py"]
+include = ["./src/*.py", "noxfile.py"]
 target-version = "py313"
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ nox = [
 ]
 
 [tool.ruff]
-include = ["./src/*.py", "noxfile.py"]
+include = [".src/*.py", "noxfile.py"]
 target-version = "py313"
 
 [tool.ruff.format]

--- a/src/bot.py
+++ b/src/bot.py
@@ -5,7 +5,7 @@ import arc
 import hikari
 import miru
 
-from src.config import DEBUG, TOKEN
+from src.config import DB_ENABLED, DEBUG, TOKEN
 from src.database import init_db
 
 bot = hikari.GatewayBot(
@@ -63,4 +63,5 @@ async def error_handler(ctx: arc.GatewayContext, exc: Exception) -> None:
 
 @client.add_startup_hook
 async def startup_hook(_: arc.GatewayClient) -> None:
-    await init_db()
+    if DB_ENABLED:
+        await init_db()

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,13 @@ class Feature(StrEnum):
     # the enum value should be the environment variable
     DATABASE = "DB_ENABLED"
     LDAP = "LDAP_ENABLED"
+    PERMISSION_HOOKS = "PERMS_ENABLED"
+
+    @property
+    def enabled(self) -> bool:
+        return get_env_var(
+            self.value, required=False, conv=convert_to_bool, default=True
+        )
 
 
 def convert_to_bool(value: str) -> bool:
@@ -74,10 +81,7 @@ def get_env_var(
 
     if required_features:
         for feature in required_features:
-            enabled = get_env_var(
-                feature.value, required=False, conv=convert_to_bool, default=True
-            )
-            if enabled and env is None:
+            if feature.enabled and env is None:
                 # feature is enabled, but the env var is not set!
                 logging.error(
                     f"'{name}' environment variable not set but is required for feature '{feature.name}'. Exiting."
@@ -95,16 +99,6 @@ TOKEN = get_env_var("TOKEN", required=True)
 DEBUG = get_env_var("DEBUG", required=False, conv=convert_to_bool, default=False)
 
 DISCORD_UID_MAP = get_env_var("DISCORD_UID_MAP", required=True)
-
-DB_ENABLED = get_env_var(
-    "DB_ENABLED", required=False, conv=convert_to_bool, default=True
-)
-PERMS_ENABLED = get_env_var(
-    "PERMS_ENABLED",
-    required=False,
-    conv=convert_to_bool,
-    default=True,
-)
 
 DB_HOST = get_env_var("DB_HOST", required_features=[Feature.DATABASE])
 DB_NAME = get_env_var("DB_NAME", required_features=[Feature.DATABASE])

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ DEBUG = os.environ.get("DEBUG") or False
 
 DISCORD_UID_MAP = get_required_var("DISCORD_UID_MAP")
 
+DB_ENABLED = os.environ.get("DB_ENABLED", "").strip().lower() != "false"
 DB_HOST = os.environ.get("DB_HOST")
 DB_NAME = os.environ.get("DB_NAME")
 DB_USER = os.environ.get("DB_USER")

--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,6 @@ T = typing.TypeVar("T", bound=int | str | bool)
 class Feature(StrEnum):
     # the enum value should be the environment variable
     DATABASE = "DB_ENABLED"
-    RCON = "RCON_ENABLED"
     LDAP = "LDAP_ENABLED"
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -100,6 +100,12 @@ DISCORD_UID_MAP = get_env_var("DISCORD_UID_MAP", required=True)
 DB_ENABLED = get_env_var(
     "DB_ENABLED", required=False, conv=convert_to_bool, default=True
 )
+PERMS_ENABLED = get_env_var(
+    "PERMS_ENABLED",
+    required=False,
+    conv=convert_to_bool,
+    default=True,
+)
 
 DB_HOST = get_env_var("DB_HOST", required_features=[Feature.DATABASE])
 DB_NAME = get_env_var("DB_NAME", required_features=[Feature.DATABASE])

--- a/src/database.py
+++ b/src/database.py
@@ -1,22 +1,16 @@
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
 
-from src.config import DB_ENABLED, DB_HOST, DB_NAME, DB_PASSWORD, DB_USER
+from src.config import DB_HOST, DB_NAME, DB_PASSWORD, DB_USER
 
-if DB_ENABLED:
-    engine = create_async_engine(
-        f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}", echo=False
-    )
+engine = create_async_engine(
+    f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}", echo=False
+)
 
-    Base = declarative_base()
-    Session = async_sessionmaker(bind=engine)
+Base = declarative_base()
+Session = async_sessionmaker(bind=engine)
 
-    async def init_db() -> None:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
 
-else:
-    print("Database disabled due to DB_ENABLED=false in env.")
-
-    async def init_db() -> None:
-        pass
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/src/database.py
+++ b/src/database.py
@@ -1,17 +1,22 @@
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
 
-from src.config import DB_HOST, DB_NAME, DB_PASSWORD, DB_USER
+from src.config import DB_ENABLED, DB_HOST, DB_NAME, DB_PASSWORD, DB_USER
 
-engine = create_async_engine(
-    f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}", echo=False
-)
+if DB_ENABLED:
+    engine = create_async_engine(
+        f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}", echo=False
+    )
 
+    Base = declarative_base()
+    Session = async_sessionmaker(bind=engine)
 
-Base = declarative_base()
-Session = async_sessionmaker(bind=engine)
+    async def init_db() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
+else:
+    print("Database disabled due to DB_ENABLED=false in env.")
 
-async def init_db() -> None:
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    async def init_db() -> None:
+        pass

--- a/src/examples/commands.py
+++ b/src/examples/commands.py
@@ -1,11 +1,13 @@
 import arc
 
-plugin = arc.GatewayPlugin(name="Example Commands")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin(name="Example Commands")
 
 
 @plugin.include
 @arc.slash_command("hello", "Say hello!")
-async def hello(ctx: arc.GatewayContext) -> None:
+async def hello(ctx: BlockbotContext) -> None:
     """An individual command, invoked by `/hello`."""
     await ctx.respond("Hello from hikari and hikari-arc!")
 
@@ -18,7 +20,7 @@ group = plugin.include_slash_group(
 
 @group.include
 @arc.slash_subcommand("sub_command", "A sub command")
-async def sub_command(ctx: arc.GatewayContext) -> None:
+async def sub_command(ctx: BlockbotContext) -> None:
     """A subcommand, invoked by `/base_command sub_command`."""
     await ctx.respond("Hello, world! This is a sub command")
 
@@ -28,11 +30,11 @@ sub_group = group.include_subgroup("sub_group", "A subgroup to add commands to."
 
 @sub_group.include
 @arc.slash_subcommand("sub_command", "A subgroup subcommand.")
-async def sub_group_sub_command(ctx: arc.GatewayContext) -> None:
+async def sub_group_sub_command(ctx: BlockbotContext) -> None:
     """A subcommand belonging to a subgroup, invoked by `/base_group sub_group sub_command`."""
     await ctx.respond("This is a subgroup subcommand.")
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/examples/components.py
+++ b/src/examples/components.py
@@ -2,7 +2,9 @@ import arc
 import hikari
 import miru
 
-plugin = arc.GatewayPlugin("Example Components")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin("Example Components")
 
 
 class View(miru.View):
@@ -72,7 +74,7 @@ class View(miru.View):
 @plugin.include
 @arc.slash_command("components", "A command with components.")
 async def components_cmd(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     miru_client: miru.Client = arc.inject(),
 ) -> None:
     view = View(ctx.user.id)
@@ -82,5 +84,5 @@ async def components_cmd(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/examples/modals.py
+++ b/src/examples/modals.py
@@ -2,7 +2,9 @@ import arc
 import hikari
 import miru
 
-plugin = arc.GatewayPlugin("Example Modal")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin("Example Modal")
 
 
 # Modals Guide: https://miru.hypergonial.com/guides/modals/
@@ -31,7 +33,7 @@ class MyModal(miru.Modal, title="Tell us about yourself!"):
 @plugin.include
 @arc.slash_command("modal", "A command with a modal response.")
 async def modal_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     miru_client: miru.Client = arc.inject(),
 ) -> None:
     modal = MyModal()
@@ -44,5 +46,5 @@ async def modal_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/examples/options.py
+++ b/src/examples/options.py
@@ -1,14 +1,16 @@
 import arc
 import hikari
 
-plugin = arc.GatewayPlugin("Example Options")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin("Example Options")
 
 
 # Options Guide: https://arc.hypergonial.com/guides/options/
 @plugin.include
 @arc.slash_command("options", "A command with options")
 async def options(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     str_option: arc.Option[str, arc.StrParams("A string option.", name="string")],
     int_option: arc.Option[
         int,
@@ -43,5 +45,5 @@ async def options(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/action_items.py
+++ b/src/extensions/action_items.py
@@ -4,9 +4,9 @@ import aiohttp
 import arc
 import hikari
 
-from src.config import CHANNEL_IDS, ROLE_IDS, UID_MAPS
+from src.config import CHANNEL_IDS, ROLE_IDS, UID_MAPS, Feature
 from src.hooks import restrict_to_channels, restrict_to_roles
-from src.models import Blockbot, BlockbotContext, BlockbotPlugin, Feature
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 from src.utils import get_md_content, role_mention
 
 plugin = BlockbotPlugin(name="Action Items", required_features=[Feature.LDAP])

--- a/src/extensions/action_items.py
+++ b/src/extensions/action_items.py
@@ -6,12 +6,13 @@ import hikari
 
 from src.config import CHANNEL_IDS, ROLE_IDS, UID_MAPS
 from src.hooks import restrict_to_channels, restrict_to_roles
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin, Feature
 from src.utils import get_md_content, role_mention
 
-action_items = arc.GatewayPlugin(name="Action Items")
+plugin = BlockbotPlugin(name="Action Items", required_features=[Feature.LDAP])
 
 
-@action_items.include
+@plugin.include
 @arc.with_hook(restrict_to_channels(channel_ids=[CHANNEL_IDS["action-items"]]))
 @arc.with_hook(restrict_to_roles(role_ids=[ROLE_IDS["committee"]]))
 @arc.slash_command(
@@ -20,7 +21,7 @@ action_items = arc.GatewayPlugin(name="Action Items")
     autodefer=arc.AutodeferMode.EPHEMERAL,
 )
 async def get_action_items(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     url: arc.Option[str, arc.StrParams("URL of the minutes from the MD")],
     aiohttp_client: aiohttp.ClientSession = arc.inject(),
 ) -> None:
@@ -79,14 +80,14 @@ async def get_action_items(
         formatted_bullet_points[i] = item
 
     # Send title to the action-items channel
-    await action_items.client.rest.create_message(
+    await plugin.client.rest.create_message(
         CHANNEL_IDS["action-items"],
         content="# Action Items:",
     )
 
     # send each bullet point separately
     for item in formatted_bullet_points:
-        message = await action_items.client.rest.create_message(
+        message = await plugin.client.rest.create_message(
             CHANNEL_IDS["action-items"],
             mentions_everyone=False,
             user_mentions=True,
@@ -94,7 +95,7 @@ async def get_action_items(
             content=item,
         )
 
-        await action_items.client.rest.add_reaction(
+        await plugin.client.rest.add_reaction(
             channel=message.channel_id,
             message=message.id,
             emoji="✅",
@@ -112,7 +113,7 @@ async def check_valid_reaction(
     event: hikari.GuildReactionAddEvent | hikari.GuildReactionDeleteEvent,
     message: hikari.PartialMessage,
 ) -> bool:
-    bot_user = action_items.client.app.get_me()
+    bot_user = plugin.client.app.get_me()
     if not bot_user:  # bot_user will always be available after the bot has started
         return False
 
@@ -147,21 +148,21 @@ async def validate_user_reaction(
     if user_id in mentioned_ids:
         return True
 
-    member = action_items.client.cache.get_member(
+    member = plugin.client.cache.get_member(
         guild_id,
         user_id,
-    ) or await action_items.client.rest.fetch_member(guild_id, user_id)
+    ) or await plugin.client.rest.fetch_member(guild_id, user_id)
 
     # user's role is mentioned
     return any(role_id in mentioned_ids for role_id in member.role_ids)
 
 
-@action_items.listen()
+@plugin.listen()
 async def reaction_add(event: hikari.GuildReactionAddEvent) -> None:
     # retrieve the message that was reacted to
-    message = action_items.client.cache.get_message(
+    message = plugin.client.cache.get_message(
         event.message_id,
-    ) or await action_items.client.rest.fetch_message(
+    ) or await plugin.client.rest.fetch_message(
         event.channel_id,
         event.message_id,
     )
@@ -184,18 +185,18 @@ async def reaction_add(event: hikari.GuildReactionAddEvent) -> None:
     if not message.content.startswith("- ✅ ~~"):
         # add strikethrough and checkmark
         updated_content = f"- ✅ ~~{message.content[2:]}~~"
-        await action_items.client.rest.edit_message(
+        await plugin.client.rest.edit_message(
             event.channel_id,
             event.message_id,
             content=updated_content,
         )
 
 
-@action_items.listen()
+@plugin.listen()
 async def reaction_remove(event: hikari.GuildReactionDeleteEvent) -> None:
     # retrieve the message that was un-reacted to
     # NOTE: cannot use cached message as the reaction count will be outdated
-    message = await action_items.client.rest.fetch_message(
+    message = await plugin.client.rest.fetch_message(
         event.channel_id,
         event.message_id,
     )
@@ -231,7 +232,7 @@ async def reaction_remove(event: hikari.GuildReactionDeleteEvent) -> None:
     if message.content.startswith("- ✅ ~~") and valid_reaction_count == 0:
         # add strikethrough and checkmark
         updated_content = f"- {message.content[6:-2]}"
-        await action_items.client.rest.edit_message(
+        await plugin.client.rest.edit_message(
             event.channel_id,
             event.message_id,
             content=updated_content,
@@ -239,5 +240,5 @@ async def reaction_remove(event: hikari.GuildReactionDeleteEvent) -> None:
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
-    client.add_plugin(action_items)
+def loader(client: Blockbot) -> None:
+    client.add_plugin(plugin)

--- a/src/extensions/agenda.py
+++ b/src/extensions/agenda.py
@@ -83,7 +83,7 @@ async def gen_agenda(
     url: arc.Option[
         str,
         arc.StrParams("URL of the agenda template from the MD"),
-    ] = AGENDA_TEMPLATE_URL,
+    ] = AGENDA_TEMPLATE_URL,  # pyright: ignore[reportArgumentType] - it is guaranteed to exist because of runtime checks!
     aiohttp_client: aiohttp.ClientSession = arc.inject(),
 ) -> None:
     """Generate a new agenda for committee meetings."""

--- a/src/extensions/agenda.py
+++ b/src/extensions/agenda.py
@@ -6,9 +6,15 @@ import hikari
 
 from src.config import AGENDA_TEMPLATE_URL, CHANNEL_IDS, ROLE_IDS, UID_MAPS
 from src.hooks import restrict_to_channels, restrict_to_roles
-from src.utils import get_md_content, post_new_md_content, role_mention, utcnow
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin, Feature
+from src.utils import (
+    get_md_content,
+    post_new_md_content,
+    role_mention,
+    utcnow,
+)
 
-plugin = arc.GatewayPlugin(name="Agenda")
+plugin = BlockbotPlugin(name="Agenda", required_features=[Feature.LDAP])
 
 agenda = plugin.include_slash_group("agenda", "Interact with the agenda.")
 
@@ -55,7 +61,7 @@ def generate_time_choices() -> list[str]:
     autodefer=arc.AutodeferMode.EPHEMERAL,
 )
 async def gen_agenda(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     date: arc.Option[
         str,
         arc.StrParams("Select a date.", autocomplete_with=generate_date_choices),
@@ -173,9 +179,7 @@ async def gen_agenda(
     "template",
     "View the agenda template",
 )
-async def view_template(
-    ctx: arc.GatewayContext,
-) -> None:
+async def view_template(ctx: BlockbotContext) -> None:
     """View the agenda template."""
 
     embed = hikari.Embed(
@@ -195,5 +199,5 @@ async def view_template(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/agenda.py
+++ b/src/extensions/agenda.py
@@ -4,9 +4,9 @@ import aiohttp
 import arc
 import hikari
 
-from src.config import AGENDA_TEMPLATE_URL, CHANNEL_IDS, ROLE_IDS, UID_MAPS
+from src.config import AGENDA_TEMPLATE_URL, CHANNEL_IDS, ROLE_IDS, UID_MAPS, Feature
 from src.hooks import restrict_to_channels, restrict_to_roles
-from src.models import Blockbot, BlockbotContext, BlockbotPlugin, Feature
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 from src.utils import (
     get_md_content,
     post_new_md_content,

--- a/src/extensions/boosts.py
+++ b/src/extensions/boosts.py
@@ -2,9 +2,10 @@ import arc
 import hikari
 
 from src.config import CHANNEL_IDS
+from src.models import Blockbot, BlockbotPlugin
 from src.utils import get_guild
 
-plugin = arc.GatewayPlugin(name="Boosts")
+plugin = BlockbotPlugin(name="Boosts")
 
 BOOST_TIERS: list[hikari.MessageType] = [
     hikari.MessageType.USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1,
@@ -60,5 +61,5 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/figlet.py
+++ b/src/extensions/figlet.py
@@ -2,7 +2,9 @@ import arc
 import hikari
 from pyfiglet import Figlet  # pyright: ignore[reportMissingTypeStubs]
 
-plugin = arc.GatewayPlugin(name="figlet")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin(name="figlet")
 
 fonts = [
     "standard",
@@ -27,7 +29,7 @@ fonts = [
 @plugin.include
 @arc.slash_command("figlet", "ASCIIify your words!")
 async def figlet_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     text: arc.Option[str, arc.StrParams("Your words to ASCIIify.")],
     font: arc.Option[
         str,
@@ -70,5 +72,5 @@ async def figlet_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/fortune.py
+++ b/src/extensions/fortune.py
@@ -2,13 +2,15 @@ import arc
 import hikari
 from fortune import fortune  # pyright: ignore[reportMissingTypeStubs]
 
-fortune_cmd = arc.GatewayPlugin(name="fortune")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin(name="fortune")
 
 
-@fortune_cmd.include
+@plugin.include
 @arc.slash_command("fortune", "Send a user a random Fortune!")
 async def fortune_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     user: arc.Option[hikari.User | None, arc.UserParams("A user")] = None,
 ) -> None:
     """Send a random Fortune!"""
@@ -41,5 +43,5 @@ async def fortune_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
-    client.add_plugin(fortune_cmd)
+def loader(client: Blockbot) -> None:
+    client.add_plugin(plugin)

--- a/src/extensions/gerry.py
+++ b/src/extensions/gerry.py
@@ -2,16 +2,17 @@ import arc
 import hikari
 
 from src.config import Colour
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 
-gerry = arc.GatewayPlugin(name="gerry")
+plugin = BlockbotPlugin(name="gerry")
 
 image = "https://cdn.redbrick.dcu.ie/blockbot/gerry.jpg"
 
 
-@gerry.include
+@plugin.include
 @arc.slash_command("gerry", "So tell me Frank!")
 async def gerry_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     user: arc.Option[
         hikari.User | None,
         arc.UserParams("The user to send a gerry to."),
@@ -34,5 +35,5 @@ async def gerry_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
-    client.add_plugin(gerry)
+def loader(client: Blockbot) -> None:
+    client.add_plugin(plugin)

--- a/src/extensions/help.py
+++ b/src/extensions/help.py
@@ -5,7 +5,6 @@ import arc
 import hikari
 
 from src.config import Colour
-
 from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 
 plugin = BlockbotPlugin(name="Help Command Plugin")

--- a/src/extensions/help.py
+++ b/src/extensions/help.py
@@ -6,7 +6,9 @@ import hikari
 
 from src.config import Colour
 
-plugin = arc.GatewayPlugin(name="Help Command Plugin")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+plugin = BlockbotPlugin(name="Help Command Plugin")
 
 
 def gather_commands() -> dict[str | None, list[str]]:
@@ -29,7 +31,7 @@ def gather_commands() -> dict[str | None, list[str]]:
 
 @plugin.include
 @arc.slash_command("help", "Displays a list of all commands.")
-async def help_command(ctx: arc.GatewayContext) -> None:
+async def help_command(ctx: BlockbotContext) -> None:
     """Displays a simple list of all bot commands."""
 
     plugin_commands = gather_commands()
@@ -46,5 +48,5 @@ async def help_command(ctx: arc.GatewayContext) -> None:
 
 
 @arc.loader
-def load(client: arc.GatewayClient) -> None:
+def load(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/register.py
+++ b/src/extensions/register.py
@@ -8,9 +8,10 @@ import miru
 
 from src.config import CHANNEL_IDS, ROLE_IDS
 from src.hooks import restrict_to_channels
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 from src.utils import role_mention
 
-plugin = arc.GatewayPlugin(name="Register")
+plugin = BlockbotPlugin(name="Register")
 
 USERNAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9_]{1,6}[a-z0-9]$")
 STUDENT_ID_REGEX = re.compile(r"[0-9]{5,9}")
@@ -108,7 +109,7 @@ class RegisterView(miru.View):
     autodefer=arc.AutodeferMode.EPHEMERAL,  # ensure all responses are ephemeral if auto defer responds first
 )
 async def register_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     student_id: arc.Option[
         str, arc.StrParams(description="Your student ID.", min_length=5, max_length=9)
     ],
@@ -169,5 +170,5 @@ async def register_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/uptime.py
+++ b/src/extensions/uptime.py
@@ -1,16 +1,17 @@
 import arc
 
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 from src.utils import utcnow
 
-start_time = utcnow()
+START_TIME = utcnow()
 
-plugin = arc.GatewayPlugin("Blockbot Uptime")
+plugin = BlockbotPlugin("Blockbot Uptime")
 
 
 @plugin.include
 @arc.slash_command("uptime", "Show formatted uptime of Blockbot")
-async def uptime(ctx: arc.GatewayContext) -> None:
-    up_time = utcnow() - start_time
+async def uptime(ctx: BlockbotContext) -> None:
+    up_time = utcnow() - START_TIME
     d = up_time.days
     h, ms = divmod(up_time.seconds, 3600)
     m, s = divmod(ms, 60)
@@ -25,5 +26,5 @@ async def uptime(ctx: arc.GatewayContext) -> None:
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/user_roles.py
+++ b/src/extensions/user_roles.py
@@ -2,9 +2,10 @@ import arc
 import hikari
 
 from src.config import ASSIGNABLE_ROLES
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 from src.utils import role_mention
 
-plugin = arc.GatewayPlugin(name="User Roles")
+plugin = BlockbotPlugin(name="User Roles")
 
 role = plugin.include_slash_group("role", "Get/remove assignable roles.")
 
@@ -17,7 +18,7 @@ role_choices = [
 @role.include
 @arc.slash_subcommand("add", "Add an assignable role.")
 async def add_role(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     role: arc.Option[str, arc.StrParams("The role to add.", choices=role_choices)],
 ) -> None:
     # commands are not available in DMs, so guild_id and member will always be available
@@ -46,7 +47,7 @@ async def add_role(
 @role.include
 @arc.slash_subcommand("remove", "Remove an assignable role.")
 async def remove_role(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     role: arc.Option[str, arc.StrParams("The role to remove.", choices=role_choices)],
 ) -> None:
     # commands are not available in DMs, so guild_id and member will always be available
@@ -73,7 +74,7 @@ async def remove_role(
 
 
 @role.set_error_handler
-async def role_error_handler(ctx: arc.GatewayContext, exc: Exception) -> None:
+async def role_error_handler(ctx: BlockbotContext, exc: Exception) -> None:
     role = ctx.get_option("role", arc.OptionType.STRING)
     assert role is not None
 
@@ -95,5 +96,5 @@ async def role_error_handler(ctx: arc.GatewayContext, exc: Exception) -> None:
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/verify.py
+++ b/src/extensions/verify.py
@@ -3,8 +3,9 @@ import hikari
 
 from src.config import CHANNEL_IDS, ROLE_IDS, Colour
 from src.hooks import restrict_to_channels, restrict_to_roles
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
 
-plugin = arc.GatewayPlugin(name="Verify")
+plugin = BlockbotPlugin(name="Verify")
 
 
 @plugin.include
@@ -17,7 +18,7 @@ plugin = arc.GatewayPlugin(name="Verify")
     "Verify a Redbrick account.",
 )
 async def verify_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     username: arc.Option[
         str,
         arc.StrParams("Redbrick username.", min_length=3, max_length=8),
@@ -71,5 +72,5 @@ async def verify_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/welcome.py
+++ b/src/extensions/welcome.py
@@ -2,9 +2,10 @@ import arc
 import hikari
 
 from src.config import CHANNEL_IDS
+from src.models import Blockbot, BlockbotPlugin
 from src.utils import channel_mention, get_guild
 
-plugin = arc.GatewayPlugin(name="Welcome")
+plugin = BlockbotPlugin(name="Welcome")
 
 
 @plugin.listen()
@@ -34,5 +35,5 @@ async def on_member_join(event: hikari.MemberCreateEvent) -> None:
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(plugin)

--- a/src/extensions/xkcd.py
+++ b/src/extensions/xkcd.py
@@ -4,13 +4,15 @@ import aiohttp
 import arc
 import hikari
 
-xkcd = arc.GatewayPlugin(name="xkcd")
+from src.models import Blockbot, BlockbotContext, BlockbotPlugin
+
+xkcd = BlockbotPlugin(name="xkcd")
 
 
 @xkcd.include
 @arc.slash_command("xkcd", "Wisdom from xkcd!")
 async def xkcd_command(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     num: arc.Option[
         int | None, arc.IntParams("Optionally specify an xkcd number.")
     ] = None,
@@ -61,5 +63,5 @@ async def xkcd_command(
 
 
 @arc.loader
-def loader(client: arc.GatewayClient) -> None:
+def loader(client: Blockbot) -> None:
     client.add_plugin(xkcd)

--- a/src/hooks.py
+++ b/src/hooks.py
@@ -4,7 +4,7 @@ import typing
 import arc
 import hikari
 
-from src.config import PERMS_ENABLED
+from src.config import Feature
 from src.models import BlockbotContext
 
 type WrappedHookResult = typing.Callable[
@@ -14,7 +14,7 @@ type WrappedHookResult = typing.Callable[
 
 def can_be_disabled(func: WrappedHookResult) -> WrappedHookResult:
     async def wrapper(ctx: BlockbotContext) -> arc.HookResult:
-        if not PERMS_ENABLED:
+        if not Feature.PERMISSION_HOOKS.enabled:
             logging.warning(
                 f"permission hook disabled; bypassing restrictions for '{ctx.command.name}' command"
             )

--- a/src/hooks.py
+++ b/src/hooks.py
@@ -3,10 +3,15 @@ import typing
 import arc
 import hikari
 
-type WrappedHookResult = typing.Callable[[arc.GatewayContext], typing.Awaitable[arc.HookResult]]
+from src.models import BlockbotContext
+
+type WrappedHookResult = typing.Callable[
+    [BlockbotContext], typing.Awaitable[arc.HookResult]
+]
+
 
 async def _restrict_to_roles(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     role_ids: typing.Sequence[int],
 ) -> arc.HookResult:
     assert ctx.member
@@ -26,14 +31,14 @@ def restrict_to_roles(
 ) -> WrappedHookResult:
     """Any command which uses this hook requires that the command be disabled in DMs as a guild role is required for this hook to function."""
 
-    async def func(ctx: arc.GatewayContext) -> arc.HookResult:
+    async def func(ctx: BlockbotContext) -> arc.HookResult:
         return await _restrict_to_roles(ctx, role_ids)
 
     return func
 
 
 async def _restrict_to_channels(
-    ctx: arc.GatewayContext,
+    ctx: BlockbotContext,
     channel_ids: typing.Sequence[int],
 ) -> arc.HookResult:
     if ctx.channel_id not in channel_ids:
@@ -49,7 +54,7 @@ async def _restrict_to_channels(
 def restrict_to_channels(
     channel_ids: typing.Sequence[int],
 ) -> WrappedHookResult:
-    async def func(ctx: arc.GatewayContext) -> arc.HookResult:
+    async def func(ctx: BlockbotContext) -> arc.HookResult:
         return await _restrict_to_channels(ctx, channel_ids)
 
     return func

--- a/src/hooks.py
+++ b/src/hooks.py
@@ -12,25 +12,31 @@ type WrappedHookResult = typing.Callable[
 ]
 
 
+def can_be_disabled(func: WrappedHookResult) -> WrappedHookResult:
+    async def wrapper(ctx: BlockbotContext) -> arc.HookResult:
+        if not PERMS_ENABLED:
+            logging.warning(
+                f"permission hook disabled; bypassing restrictions for '{ctx.command.name}' command"
+            )
+            return arc.HookResult(abort=False)
+
+        return await func(ctx)
+
+    return wrapper
+
+
 async def _restrict_to_roles(
     ctx: BlockbotContext,
     role_ids: typing.Sequence[int],
 ) -> arc.HookResult:
     assert ctx.member
 
-    if PERMS_ENABLED and not any(
-        role_id in ctx.member.role_ids for role_id in role_ids
-    ):
+    if not all(role_id in ctx.member.role_ids for role_id in role_ids):
         await ctx.respond(
             "❌ This command is restricted. Only allowed roles are permitted to use this command.",
             flags=hikari.MessageFlag.EPHEMERAL,
         )
         return arc.HookResult(abort=True)
-
-    if not PERMS_ENABLED:
-        logging.warning(
-            f"permission hooks disabled; bypassing role restrictions for '{ctx.command.name}' command"
-        )
 
     return arc.HookResult()  # by default, abort is set to False
 
@@ -40,6 +46,7 @@ def restrict_to_roles(
 ) -> WrappedHookResult:
     """Any command which uses this hook requires that the command be disabled in DMs as a guild role is required for this hook to function."""
 
+    @can_be_disabled
     async def func(ctx: BlockbotContext) -> arc.HookResult:
         return await _restrict_to_roles(ctx, role_ids)
 
@@ -50,17 +57,12 @@ async def _restrict_to_channels(
     ctx: BlockbotContext,
     channel_ids: typing.Sequence[int],
 ) -> arc.HookResult:
-    if PERMS_ENABLED and ctx.channel_id not in channel_ids:
+    if ctx.channel_id not in channel_ids:
         await ctx.respond(
             "❌ This command cannot be used in this channel.",
             flags=hikari.MessageFlag.EPHEMERAL,
         )
         return arc.HookResult(abort=True)
-
-    if not PERMS_ENABLED:
-        logging.warning(
-            f"permission hooks disabled; bypassing channel restrictions for '{ctx.command.name}' command"
-        )
 
     return arc.HookResult()
 
@@ -68,6 +70,7 @@ async def _restrict_to_channels(
 def restrict_to_channels(
     channel_ids: typing.Sequence[int],
 ) -> WrappedHookResult:
+    @can_be_disabled
     async def func(ctx: BlockbotContext) -> arc.HookResult:
         return await _restrict_to_channels(ctx, channel_ids)
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import enum
+import logging
+import typing
+
+import arc
+
+from src.config import convert_to_bool, get_env_var
+
+
+class Feature(enum.StrEnum):
+    # the enum value should be the environment variable
+    DATABASE = "DB_ENABLED"
+    RCON = "RCON_ENABLED"
+    LDAP = "LDAP_ENABLED"
+
+
+type BlockbotContext = arc.Context[Blockbot]
+
+
+class Blockbot(arc.GatewayClient):
+    def add_plugin(self, plugin: BlockbotPlugin) -> typing.Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        plugin_enabled: bool = True
+
+        for feature in plugin.required_features:
+            enabled = get_env_var(
+                feature.value, required=False, conv=convert_to_bool, default=True
+            )
+            if not enabled:
+                plugin_enabled = False
+                break
+
+        if plugin_enabled:
+            super().add_plugin(plugin)  # pyright: ignore[reportArgumentType]
+
+        logging.debug(
+            f"plugin '{plugin.name}' is {'enabled' if plugin_enabled else 'disabled'}"
+        )
+
+        return self
+
+
+class BlockbotPlugin(arc.GatewayPluginBase[Blockbot]):
+    def __init__(
+        self, name: str, required_features: typing.Sequence[Feature] | None = None
+    ) -> None:
+        self._required_features = required_features or []
+        super().__init__(name)
+
+    @property
+    def required_features(self) -> typing.Sequence[Feature]:
+        """The features required for this plugin to be enabled."""
+        return self._required_features

--- a/src/models.py
+++ b/src/models.py
@@ -5,7 +5,8 @@ import typing
 
 import arc
 
-from src.config import Feature, convert_to_bool, get_env_var
+if typing.TYPE_CHECKING:
+    from src.config import Feature
 
 type BlockbotContext = arc.Context[Blockbot]
 
@@ -15,10 +16,7 @@ class Blockbot(arc.GatewayClient):
         plugin_enabled: bool = True
 
         for feature in plugin.required_features:
-            enabled = get_env_var(
-                feature.value, required=False, conv=convert_to_bool, default=True
-            )
-            if not enabled:
+            if not feature.enabled:
                 plugin_enabled = False
                 break
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,20 +1,11 @@
 from __future__ import annotations
 
-import enum
 import logging
 import typing
 
 import arc
 
-from src.config import convert_to_bool, get_env_var
-
-
-class Feature(enum.StrEnum):
-    # the enum value should be the environment variable
-    DATABASE = "DB_ENABLED"
-    RCON = "RCON_ENABLED"
-    LDAP = "LDAP_ENABLED"
-
+from src.config import Feature, convert_to_bool, get_env_var
 
 type BlockbotContext = arc.Context[Blockbot]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,21 +1,20 @@
 import datetime
+import typing
 from urllib.parse import urlparse
 
 import aiohttp
 import arc
 import hikari
-import typing
 
 from src.config import LDAP_PASSWORD, LDAP_USERNAME
 
 
 class EventWithGuildAttributes(typing.Protocol):
     @property
-    def guild_id(self) -> hikari.Snowflake:
-        ...
+    def guild_id(self) -> hikari.Snowflake: ...
 
-    def get_guild(self) -> hikari.GatewayGuild | None:
-        ...
+    def get_guild(self) -> hikari.GatewayGuild | None: ...
+
 
 async def get_guild(
     client: arc.GatewayClient,


### PR DESCRIPTION
Adds mode for enabling/disabling "features" of blockbot for ease of development.

e.g. any plugin which has the `REQUIRES_DATABASE` feature will not be loaded if the `DB_ENABLED` env var is set to `false`.

Initial features & related env var:
- `REQUIRES_DATABASE` (`DB_ENABLED`)
- `REQUIRES_RCON` (`RCON_ENABLED`) - relies on #83
- permission hooks (`PERMS_ENABLED`) - enables/disables permission hooks defined in `hooks.py`


Closes #70 