### PR TITLE
Added URL to Gerry Command 

### DIFF
--- a/src/misc/gerry.py
+++ b/src/misc/gerry.py
@@ -23,6 +23,7 @@ async def gerry_command(
 
     embed = hikari.Embed(
         title="Gerry",
+        url="https://s.rb.dcu.ie/gerry",
         description=description,
         colour=Colour.GERRY_YELLOW,
     )


### PR DESCRIPTION
This PR adds the Gerry URL to the embed when it is sent, making the title clickable.

Closes #103 