### PR TITLE
Fix auto-defer for minio upload command

### DIFF
--- a/src/extensions/storage.py
+++ b/src/extensions/storage.py
@@ -60,7 +60,11 @@ async def minio_prefix_exists(bucket_name: str, prefix: str) -> bool:
 
 @minio.include
 @arc.with_hook(restrict_to_roles(role_ids=[ROLE_IDS["committee"]]))
-@arc.slash_command("upload", "Upload a file to the storage server.")
+@arc.slash_command(
+    "upload",
+    "Upload a file to the storage server.",
+    autodefer=arc.AutodeferMode.EPHEMERAL,
+)
 async def upload_command(
     ctx: BlockbotContext,
     bucket_name: arc.Option[


### PR DESCRIPTION
Previously if you were to upload a large image, that might take more than 3 seconds so arc's auto defer logic will kick in. However this sets the deferred response to *not* be ephemeral, but as we want all responses to be ephemeral, this configuration needs to be changed.